### PR TITLE
upd mockery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,11 @@
     },
     "autoload": {
         "psr-4": {
-            "duncan3dc\\MetaAudio\\": "src/",
+            "duncan3dc\\MetaAudio\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "duncan3dc\\MetaAudioTests\\": "tests/"
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require-dev": {
         "duncan3dc/object-intruder": "^0.3",
         "duncan3dc/php-ini": "^0.1.0",
-        "mockery/mockery": "^0.9.9",
-        "phpunit/phpunit": "^5.7.1",
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^5.7.6",
         "satooshi/php-coveralls": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "duncan3dc/object-intruder": "^0.3",
         "duncan3dc/php-ini": "^0.1.0",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^5.7.6",
+        "phpunit/phpunit": "^5.7.7",
         "satooshi/php-coveralls": "^1.0"
     },
     "autoload": {

--- a/src/Modules/Ape.php
+++ b/src/Modules/Ape.php
@@ -4,6 +4,7 @@ namespace duncan3dc\MetaAudio\Modules;
 
 use duncan3dc\MetaAudio\Exceptions\ApeParseException;
 use duncan3dc\MetaAudio\Exceptions\BadMethodCallException;
+use duncan3dc\MetaAudio\Utils\Bit;
 
 /**
  * Handle APE tags.
@@ -93,7 +94,7 @@ class Ape extends AbstractModule
             "size"      =>  $size,
             "items"     =>  $items,
             "flags"     =>  $flags,
-            "footer"    =>  !($flags & 0x20),
+            "footer"    =>  Bit::isOff($flags, 29),
         ];
 
         # Skip the empty space at the end of the header

--- a/src/Modules/Ape.php
+++ b/src/Modules/Ape.php
@@ -225,6 +225,12 @@ class Ape extends AbstractModule
         # Generate the new ape tags
         $tags = $this->createTagData($tags);
 
+        # Retain any ID3v1 tags that are in use
+        if (substr($contents, -128, 3) === Id3v1::PREAMBLE) {
+            $tags .= substr($contents, -128);
+            $contents = substr($contents, 0, -128);
+        }
+
         # Empty the file and position at the start so we can overwrite
         $this->file->ftruncate(0);
         $this->file->rewind();

--- a/src/Modules/Id3v2.php
+++ b/src/Modules/Id3v2.php
@@ -2,8 +2,9 @@
 
 namespace duncan3dc\MetaAudio\Modules;
 
-use duncan3dc\MetaAudio\Exception;
 use duncan3dc\Bom\Util as Bom;
+use duncan3dc\MetaAudio\Exception;
+use duncan3dc\MetaAudio\Utils\Bit;
 
 /**
  * Handle ID3v2.4 tags.
@@ -118,12 +119,12 @@ class Id3v2 extends AbstractModule
             "version"   =>  $version,
             "flags"     =>  $flags,
             "size"      =>  $this->fromSynchsafeInt($this->file->fread(4)),
-            "unsynch"   =>  (bool) ($flags & 0x80),
-            "footer"    =>  (bool) ($flags & 0x10),
+            "unsynch"   =>  Bit::isOn($flags, 7),
+            "footer"    =>  Bit::isOn($flags, 4),
         ];
 
         # Skip the extended header
-        if ($flags & 0x40) {
+        if (Bit::isOn($flags, 6)) {
             $size = $this->fromSynchsafeInt($this->file->fread(4));
             $this->file->fread($size - 4);
             $header["size"] -= $size;

--- a/src/Utils/Bit.php
+++ b/src/Utils/Bit.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace duncan3dc\MetaAudio\Utils;
+
+/**
+ * Class to handle bit check/updates.
+ * $bit is the positiion, the least significant is 0 (eg in 1000 the 3rd bit is on, bits 0, 1, and 2 are off).
+ */
+class Bit
+{
+
+    /**
+     * Check if a bit is on.
+     *
+     * @param int $value The decimal value to check
+     * @param int $bit The position of the bit
+     *
+     * @return bool true if the bit is on
+     */
+    public static function isOn($value, $bit)
+    {
+        return (bool) ($value & (1 << $bit));
+    }
+
+
+    /**
+     * Check if a bit is off.
+     *
+     * @param int $value The decimal value to check
+     * @param int $bit The position of the bit
+     *
+     * @return bool true if the bit is off
+     */
+    public static function isOff($value, $bit)
+    {
+        return !static::isOn($value, $bit);
+    }
+}

--- a/src/Utils/Bit.php
+++ b/src/Utils/Bit.php
@@ -35,4 +35,32 @@ class Bit
     {
         return !static::isOn($value, $bit);
     }
+
+
+    /**
+     * Update the value to turn a bit on.
+     *
+     * @param int $value The decimal value to update
+     * @param int $bit The position of the bit
+     *
+     * @return int
+     */
+    public static function turnOn($value, $bit)
+    {
+        return ($value | (1 << $bit));
+    }
+
+
+    /**
+     * Update the value to turn a bit off.
+     *
+     * @param int $value The decimal value to update
+     * @param int $bit The position of the bit
+     *
+     * @return int
+     */
+    public static function turnOff($value, $bit)
+    {
+        return ($value & ~(1 << $bit));
+    }
 }

--- a/tests/Ape/Test.php
+++ b/tests/Ape/Test.php
@@ -43,7 +43,7 @@ class Test extends \PHPUnit_Framework_TestCase
     {
         $original = $this->getFile("extra_corrupt_tags_at_end");
 
-        $tmp = tempnam("/tmp", "meta-audio-");
+        $tmp = tempnam(sys_get_temp_dir(), "meta-audio-");
         $file = new File($tmp);
         $file->fwrite($original->readAll());
 

--- a/tests/Auto/Test.php
+++ b/tests/Auto/Test.php
@@ -15,7 +15,7 @@ class Test extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->tmp = tempnam("/tmp", "meta-audio-");
+        $this->tmp = tempnam(sys_get_temp_dir(), "meta-audio-");
     }
 
 

--- a/tests/ConvertTest.php
+++ b/tests/ConvertTest.php
@@ -14,7 +14,7 @@ class ConvertTest extends \PHPUnit_Framework_TestCase
 
     private function rewrite_an_old_file_with_new_tags(ModuleInterface $module)
     {
-        $tmp = tempnam("/tmp", "meta-audio-");
+        $tmp = tempnam(sys_get_temp_dir(), "meta-audio-");
         copy(__DIR__ . "/data/old.mp3", $tmp);
 
         $file = new File($tmp);

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -9,7 +9,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
     private function getTestFile($contents)
     {
-        $tmp = tempnam("/tmp", "meta-audio-");
+        $tmp = tempnam(sys_get_temp_dir(), "meta-audio-");
 
         file_put_contents($tmp, $contents);
 

--- a/tests/Modules/ApeTest.php
+++ b/tests/Modules/ApeTest.php
@@ -70,7 +70,7 @@ class ApeTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_write_all_tags()
     {
-        $tmp = tempnam("/tmp", "meta-audio-ape-");
+        $tmp = tempnam(sys_get_temp_dir(), "meta-audio-ape-");
         copy(__DIR__ . "/../data/no-tags.mp3", $tmp);
 
         $module = $this->getModule($tmp);

--- a/tests/Mp3Test.php
+++ b/tests/Mp3Test.php
@@ -163,7 +163,7 @@ class Mp3Test extends \PHPUnit_Framework_TestCase
 
     public function testWrite()
     {
-        $tmp = tempnam("/tmp", "meta-audio-");
+        $tmp = tempnam(sys_get_temp_dir(), "meta-audio-");
 
         $file = new File($tmp);
 

--- a/tests/TaggerTest.php
+++ b/tests/TaggerTest.php
@@ -14,7 +14,7 @@ class TaggerTest extends \PHPUnit_Framework_TestCase
     {
         $tagger = new Tagger;
 
-        $tmp = tempnam("/tmp", "meta-audio-");
+        $tmp = tempnam(sys_get_temp_dir(), "meta-audio-");
 
         $file = $tagger->open($tmp);
 
@@ -32,7 +32,7 @@ class TaggerTest extends \PHPUnit_Framework_TestCase
 
         $tagger->addModule($module);
 
-        $tmp = tempnam("/tmp", "meta-audio-");
+        $tmp = tempnam(sys_get_temp_dir(), "meta-audio-");
 
         $file = $tagger->open($tmp);
 

--- a/tests/Utils/BitTest.php
+++ b/tests/Utils/BitTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace duncan3dc\MetaAudioTests\Utils;
+
+use duncan3dc\MetaAudio\Utils\Bit;
+
+class BitTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function bitProvider()
+    {
+        yield [0, 0, false];
+        yield [0, 1, false];
+
+        yield [1, 0, true];
+        yield [1, 1, false];
+
+        yield [2, 0, false];
+        yield [2, 1, true];
+        yield [2, 2, false];
+
+        yield [3, 0, true];
+        yield [3, 1, true];
+        yield [3, 2, false];
+
+        # Ensure we support all 32 bits used by the library
+        $value = 4294967295;
+        for ($bit = 0; $bit <= 31; ++$bit) {
+            yield [$value, $bit, true];
+        }
+
+        # This is a 33 bit number, all bits should be off
+        $value = 4294967296;
+        for ($bit = 0; $bit <= 31; ++$bit) {
+            yield [$value, $bit, false];
+        }
+
+        # One off the maximum 32bit number should mean 31 of the 32 bits are on
+        $value = 4294967294;
+        yield [$value, 0, false];
+        for ($bit = 1; $bit <= 31; ++$bit) {
+            yield [$value, $bit, true];
+        }
+    }
+    /**
+     * @dataProvider bitProvider
+     */
+    public function testIsOn($value, $bit, $expected)
+    {
+        $this->assertSame($expected, Bit::isOn($value, $bit));
+    }
+    /**
+     * @dataProvider bitProvider
+     */
+    public function testIsOff($value, $bit, $expected)
+    {
+        $this->assertSame(!$expected, Bit::isOff($value, $bit));
+    }
+}

--- a/tests/Utils/BitTest.php
+++ b/tests/Utils/BitTest.php
@@ -56,4 +56,63 @@ class BitTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame(!$expected, Bit::isOff($value, $bit));
     }
+
+
+    public function turnOnProvider()
+    {
+        yield [0, 0, 1];
+        yield [0, 1, 2];
+
+        yield [1, 0, 1];
+        yield [1, 1, 3];
+
+        yield [2, 0, 3];
+        yield [2, 1, 2];
+        yield [2, 2, 6];
+
+        yield [3, 0, 3];
+        yield [3, 1, 3];
+        yield [3, 2, 7];
+
+        # Ensure we support all 32 bits used by the library
+        yield [4294967295, 31, 4294967295];
+        yield [2147483647, 31, 4294967295];
+    }
+    /**
+     * @dataProvider turnOnProvider
+     */
+    public function testTurnOn($value, $bit, $expected)
+    {
+        $this->assertSame($expected, Bit::turnOn($value, $bit));
+    }
+
+
+    public function turnOffProvider()
+    {
+        yield [0, 0, 0];
+        yield [0, 1, 0];
+
+        yield [1, 0, 0];
+        yield [1, 1, 1];
+
+        yield [2, 0, 2];
+        yield [2, 1, 0];
+        yield [2, 2, 2];
+
+        yield [3, 0, 2];
+        yield [3, 1, 1];
+        yield [3, 2, 3];
+
+        # Ensure we support all 32 bits used by the library
+        yield [4294967295, 31, 2147483647];
+        yield [2147483647, 31, 2147483647];
+        yield [4294967295, 0, 4294967294];
+    }
+    /**
+     * @dataProvider turnOffProvider
+     */
+    public function testTurnOff($value, $bit, $expected)
+    {
+        $this->assertSame($expected, Bit::turnOff($value, $bit));
+    }
 }


### PR DESCRIPTION
upd `mockery` to latest stable version (https://github.com/mockery/mockery/releases/tag/1.0)
this fixes tests for php >= 7.2