### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/Auto/Test.php
+++ b/tests/Auto/Test.php
@@ -13,13 +13,13 @@ class Test extends TestCase
     private $tmp;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->tmp = tempnam(sys_get_temp_dir(), "meta-audio-");
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unlink($this->tmp);
         unset($this->tmp);

--- a/tests/ModuleManagerTest.php
+++ b/tests/ModuleManagerTest.php
@@ -17,14 +17,14 @@ class ModuleManagerTest extends TestCase
     private $manager;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $manager = new ModuleManager();
         $this->manager = new Intruder($manager);
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->manager);
         Mockery::close();

--- a/tests/Modules/AbstractModuleTest.php
+++ b/tests/Modules/AbstractModuleTest.php
@@ -12,7 +12,7 @@ class AbstractModuleTest extends TestCase
 {
     private $module;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $module = new AbstractModule();
         $module->putTags([
@@ -23,7 +23,7 @@ class AbstractModuleTest extends TestCase
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->module);
     }

--- a/tests/Modules/Id3v2MockTest.php
+++ b/tests/Modules/Id3v2MockTest.php
@@ -13,7 +13,7 @@ class Id3v2MockTest extends TestCase
 {
     private $module;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $module = new Id3v2();
         $this->module = new Intruder($module);

--- a/tests/Modules/Id3v2Test.php
+++ b/tests/Modules/Id3v2Test.php
@@ -13,7 +13,7 @@ class Id3v2Test extends TestCase
 {
     private $module;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $file = new File(__DIR__ . "/../data/test.mp3");
         $this->module = new Id3v2();

--- a/tests/Mp3Test.php
+++ b/tests/Mp3Test.php
@@ -14,7 +14,7 @@ use function assertSame;
 class Mp3Test extends TestCase
 {
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
# Changed log

- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp()` and `protected function tearDown()` methods.